### PR TITLE
[sc-16052] Add codeowners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @SGNL-ai/service-owners-adapters


### PR DESCRIPTION
- Adds service owner teams as codeowners as broken out in https://docs.google.com/spreadsheets/d/1axPcK7bNu1oCuNOa_xCW44rlPORUXtRMsxPyqfZ6ARg/edit#gid=0

- IMO the setting to require an approval from codeowners should not be enabled for this repo, so codeowners are auto-request as a reviewer but are not required for a PR to be merged