### PR TITLE
bug(readme): Fix commands for updating package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ Once this file is created, set the `AUTH_TOKENS_PATH` environment variable to th
 1. Update the names of `github.com/sgnl-ai/adapter-template/*` Golang packages in all files to match your new repository's name (e.g. `github.com/your-org/your-repo`):
 
    ```
-   sed -e 's,^module github\.com/sgnl-ai/adapter-template,github.com/your-org/your-repo,' -i go.mod
+   sed -e 's,^module github\.com/sgnl-ai/adapter-template,module github.com/your-org/your-repo,' -i go.mod
    ```
 
    ```
-   find pkg/ -type f -name '*.go' | xargs -n 1 sed -n -e 's,github\.com/sgnl-ai/adapter-template,github.com/your-org/your-repo,p' -i
+   find . -type f -name '*.go' | xargs -n 1 sed -e 's,github\.com/sgnl-ai/adapter-template,github.com/your-org/your-repo,g' -i
    ```
 
 1. Modify the adapter implementation in package `pkg/adapter` to query your datasource. All the code that must be modified is identified with `SCAFFOLDING` comments. More implementation details are discussed in the [Understanding this Template](#3-understanding-this-template) section. For these steps, the code can be left as-is just to get the adapter running.


### PR DESCRIPTION
## Summary
The following commands for updating the package names (from `github.com/sgnl-ai/adapter-template` to something) are not working as expected.
```shell
sed -e 's,^module github\.com/sgnl-ai/adapter-template,github.com/your-org/your-repo,' -i go.mod
find pkg/ -type f -name '*.go' | xargs -n 1 sed -n -e 's,github\.com/sgnl-ai/adapter-template,github.com/your-org/your-repo,p' -i
```
1. nit: `module` is missing in the second half of the first command.
2. `find` should run on `cmd/main.go` too.
3. The `-n` flag is causing `sed` to empty the files in an attempt to replace a line.
4. The ending `p` in sed expression is causing to duplicate the line.

The fix updates both commands to work as expected (replace the package names inside `go.mod` and `*.go` files).

## Related to

Closes #14

## Steps to Test
1. Clone the repo, preferably somewhere inside your `GOPATH`.
2. Run the updated commands:
```shell
sed -e 's,^module github\.com/sgnl-ai/adapter-template,module github.com/your-org/your-repo,' -i go.mod
find . -type f -name '*.go' | xargs -n 1 sed -e 's,github\.com/sgnl-ai/adapter-template,github.com/your-org/your-repo,g' -i
```
3. Run a `go mod tidy` and see if it complains.
