### PR TITLE
[sc-42849] Add `flag.Parse()` on application startup 

### DIFF
--- a/cmd/adapter/main.go
+++ b/cmd/adapter/main.go
@@ -36,6 +36,8 @@ var (
 )
 
 func main() {
+	flag.Parse()
+
 	logger := log.New(os.Stdout, "adapter", log.Lmicroseconds|log.LUTC|log.Lshortfile)
 
 	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", *Port))


### PR DESCRIPTION
Fixes a bug where cmd line flags are not being read.