### PR TITLE
Log datasource request error along with message

### DIFF
--- a/pkg/adapter/datasource.go
+++ b/pkg/adapter/datasource.go
@@ -119,7 +119,7 @@ func (d *Datasource) GetPage(ctx context.Context, request *Request) (*Response, 
 	res, err := d.Client.Do(req)
 	if err != nil {
 		return nil, &framework.Error{
-			Message: "Failed to send request to datasource.",
+			Message: fmt.Sprintf("Failed to send request to datasource: %v.", err),
 			Code:    api_adapter_v1.ErrorCode_ERROR_CODE_INTERNAL,
 		}
 	}


### PR DESCRIPTION
This error message is surfaced in our ingestion service and therefore the client facing logs.
Without the actual Golang error in the message, it's difficult to debug.